### PR TITLE
Additional check whether new element is to be rendered

### DIFF
--- a/modules/ui/org.eclipse.fx.ui.workbench.fx/src/main/java/org/eclipse/fx/ui/workbench/fx/PartRenderingEngine.java
+++ b/modules/ui/org.eclipse.fx.ui.workbench.fx/src/main/java/org/eclipse/fx/ui/workbench/fx/PartRenderingEngine.java
@@ -239,7 +239,7 @@ public class PartRenderingEngine implements IPresentationEngine {
 		}
 
 		Object widget = createWidget(element);
-		if (widget != null) {
+		if (widget != null && element.isToBeRendered()) {
 			ElementRenderer<MUIElement, Object> r = getRendererFor(element);
 			r.processContent(element);
 			r.postProcess(element);


### PR DESCRIPTION
Inserted final check before rendering in PartRenderingEngine#createGui
in case isToBeRendered has been set to false during context or widget
creation.

refs #248

Signed-off-by: Elias Vasylenko <eliasvasylenko@gmail.com>