### PR TITLE
Adds *.class to global gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /org.eclipse.osgi
+*.class


### PR DESCRIPTION
I noted that some project do not exclude .class files for example the
emf.edit plug-in.
Instead of every plug-in specifying that generated class files should be
ignores I think it is better to exclude them from the root .gitignore.