### PR TITLE
Make org.eclipse.fx.ui.dialogs.MessageDialog constructor public

### DIFF
--- a/modules/ui/org.eclipse.fx.ui.dialogs/src/main/java/org/eclipse/fx/ui/dialogs/MessageDialog.java
+++ b/modules/ui/org.eclipse.fx.ui.dialogs/src/main/java/org/eclipse/fx/ui/dialogs/MessageDialog.java
@@ -159,7 +159,7 @@ public class MessageDialog extends Dialog {
 	private final int okButton;
 	private final int cancelButton;
 
-	MessageDialog(@Nullable Window parent, @NonNull String windowTitle,
+	public MessageDialog(@Nullable Window parent, @NonNull String windowTitle,
 			@NonNull String message, @NonNull Type type, int okButton,
 			int cancelButton, String... dialogButtonLabels) {
 		super(parent, windowTitle);


### PR DESCRIPTION
To allow customers and the framework to set the labels of the
MessageDialog the constructor should be public. Otherwise we have to
always extend the Dialog class

Change-Id: Iff226641018672547436bdc93a26991fef174857
Signed-off-by: Lars Vogel <Lars.Vogel@vogella.com>