### PR TITLE
321: FX Tabs do not correctly reflect changes of the Part's closeable state

### DIFF
--- a/modules/ui/org.eclipse.fx.ui.workbench.renderers.base/src/main/java/org/eclipse/fx/ui/workbench/renderers/base/BasePartRenderer.java
+++ b/modules/ui/org.eclipse.fx.ui.workbench.renderers.base/src/main/java/org/eclipse/fx/ui/workbench/renderers/base/BasePartRenderer.java
@@ -63,6 +63,7 @@ public abstract class BasePartRenderer<N, T, M> extends BaseRenderer<MPart, WPar
 
 		registerEventListener(eventBroker, UIEvents.Part.TOPIC_DESCRIPTION);
 		registerEventListener(eventBroker, UIEvents.Part.TOPIC_LOCALIZED_DESCRIPTION);
+		registerEventListener(eventBroker, UIEvents.Part.TOPIC_CLOSEABLE);
 
 		registerEventListener(eventBroker, UIEvents.Dirtyable.TOPIC_DIRTY);
 		eventBroker.subscribe(UIEvents.Part.TOPIC_MENUS, new EventHandler() {


### PR DESCRIPTION
It seems that in order to get properly re-injected, we need to properly subscribe to all required event broker topics (TOPIC_CLOSEABLE was never registered for a PartRenderer)