### PR TITLE
KeyBindings do not support the Platform tag

### DIFF
--- a/modules/ui/org.eclipse.fx.ui.keybindings.e4/META-INF/MANIFEST.MF
+++ b/modules/ui/org.eclipse.fx.ui.keybindings.e4/META-INF/MANIFEST.MF
@@ -16,6 +16,7 @@ Require-Bundle: org.eclipse.e4.core.contexts;bundle-version="1.1.0",
  org.eclipse.jdt.annotation;bundle-version="[2.0.0,3.0.0)";resolution:=optional
 Import-Package: javax.annotation;resolution:=optional,
  javax.inject;version="1.0.0",
+ org.eclipse.fx.core;version="3.6.0",
  org.eclipse.fx.core.log;version="3.6.0",
  org.eclipse.fx.ui.keybindings;version="3.6.0",
  org.eclipse.fx.ui.keybindings.service;version="3.6.0",

--- a/modules/ui/org.eclipse.fx.ui.keybindings.e4/src/main/java/org/eclipse/fx/ui/keybindings/e4/EBindingService.java
+++ b/modules/ui/org.eclipse.fx.ui.keybindings.e4/src/main/java/org/eclipse/fx/ui/keybindings/e4/EBindingService.java
@@ -60,6 +60,13 @@ public interface EBindingService {
 	 * Tag prefix for the deleted
 	 */
 	public static final String DELETED_BINDING_TAG = "deleted"; //$NON-NLS-1$
+	
+	/**
+	 * Tag prefix used by (platform- or locale-specific) KeyBindings 
+	 * to indicate which (generic) binding they override
+	 * @since 3.6
+	 */
+	public static final String OVERRIDE = "override"; //$NON-NLS-1$
 
 	/**
 	 * Create a binding between a sequence and a command


### PR DESCRIPTION
- Add support for platform: and locale: tags in the BindingProcessorAddon
- Add a new override: tag to let platform-specific bindings override generic bindings
- Let the BindingProcessorAddon filter out bindings that don't match the current platform or locale

Cross-platform bindings should usually be specified without any tag (platform/locale/override), whereas platform-specific bindings should be specified with the appropriate platform/locale, and optionally define an override: tag referencing the ID of the generic binding (If that generic binding should be disabled when the specific one is enabled).

For example, "Redo" would be specified as:

org.eclipse.ui.edit.redo.generic: M1 + M2 + Z
org.eclipse.ui.edit.redo.windows: M1 + Y; tags: platform:win32; override:org.eclipse.ui.edit.redo.generic

The generic (Ctrl/Cmd + Shift + Z) binding would apply to both Linux and Mac (And any unspecified platform), whereas the specific (Ctrl + Y) one would apply to Windows.

Platform tags have been reused from SWT and are defined as follow:

- Windows: win32, wpf
- MacOS: cocoa
- Linux: gtk

This is to simplify compatibility with existing SWT Apps, although the specific platforms (win32 vs wpf) don't make much sense for JavaFX (We want to distinguish specific OS rather than the actual UI toolkit). In E(fx), win32 and wpf are treated like they are the same value, i.e. it's probably not a good idea to override a win32 binding with a wpf binding