### PR TITLE
refs #419 - Make JAXB within org.eclipse.fx.core work with Java 11

### DIFF
--- a/modules/core/org.eclipse.fx.core/META-INF/MANIFEST.MF
+++ b/modules/core/org.eclipse.fx.core/META-INF/MANIFEST.MF
@@ -10,6 +10,11 @@ Import-Package: javax.annotation;resolution:=optional,
  org.apache.commons.lang.text;version="2.6.0",
  org.osgi.framework;version="1.8.0";resolution:=optional,
  org.osgi.service.component.annotations;version="1.2.0";resolution:=optional,
+ javax.xml.bind.annotation;resolution:=optional,
+ javax.xml.bind.annotation.adapters;resolution:=optional,
+ javax.xml.bind.attachment;resolution:=optional,
+ javax.xml.bind.helpers;resolution:=optional,
+ javax.xml.bind.util;resolution:=optional,
  org.osgi.service.event;version="1.3.1";resolution:=optional
 Export-Package: org.eclipse.fx.core;version="3.7.0",
  org.eclipse.fx.core.adapter;version="3.7.0",
@@ -43,4 +48,5 @@ Service-Component: OSGI-INF/services/org.eclipse.fx.core.internal.JAXBObjectSeri
  OSGI-INF/services/org.eclipse.fx.core.log.internal.ExceptionLogger.xml
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.jdt.annotation;bundle-version="[2.0.0,3.0.0)";resolution:=optional,
- com.google.guava;bundle-version="21.0.0"
+ com.google.guava;bundle-version="21.0.0",
+ com.sun.xml.bind;resolution:=optional

--- a/modules/core/org.eclipse.fx.core/src/main/java/org/eclipse/fx/core/internal/JAXBObjectSerializer.java
+++ b/modules/core/org.eclipse.fx.core/src/main/java/org/eclipse/fx/core/internal/JAXBObjectSerializer.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
@@ -39,103 +40,125 @@ public class JAXBObjectSerializer implements ObjectSerializer {
 
 	@Override
 	public String serialize(Object object) {
-		if (object instanceof List) {
-			object = new ListWrapper<>((List<?>) object);
-		} else if( object instanceof Set ) {
-			object = new SetWrapper<>((Set<?>)object);
-		}
-		try (StringWriter w = new StringWriter()) {
-			JAXBContext jaxbContext = JAXBContext.newInstance( object.getClass() );
-			Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
-
-			// output pretty printed
-			jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-
-			jaxbMarshaller.marshal(object, w);
-			return w.toString();
-		} catch (Throwable e) {
-			throw new RuntimeException(e);
-		}
+		return runWithThreadContextCL(() -> {
+			Object obj = object;
+			if (obj instanceof List) {
+				obj = new ListWrapper<>((List<?>) obj);
+			} else if( obj instanceof Set ) {
+				obj = new SetWrapper<>((Set<?>)obj);
+			}
+			try (StringWriter w = new StringWriter()) {
+				JAXBContext jaxbContext = JAXBContext.newInstance( obj.getClass() );
+				Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
+	
+				// output pretty printed
+				jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+	
+				jaxbMarshaller.marshal(obj, w);
+				return w.toString();
+			} catch (Throwable e) {
+				throw new RuntimeException(e);
+			}
+		});
 	}
 
 	@Override
 	public <O> String serializeCollection(Collection<O> data, Class<O> contentType) {
-		Object object;
-		if (data instanceof List) {
-			object = new ListWrapper<>((List<?>) data);
-		} else if( data instanceof Set ) {
-			object = new SetWrapper<>((Set<?>)data);
-		} else {
-			throw new IllegalArgumentException("Unsupported collection type"); //$NON-NLS-1$
-		}
-		try (StringWriter w = new StringWriter()) {
-			JAXBContext jaxbContext = JAXBContext.newInstance( object.getClass(), contentType );
-			Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
-
-			// output pretty printed
-			jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-
-			jaxbMarshaller.marshal(object, w);
-			return w.toString();
-		} catch (Throwable e) {
-			throw new RuntimeException(e);
-		}
+		return runWithThreadContextCL(() -> {
+			Object object;
+			if (data instanceof List) {
+				object = new ListWrapper<>((List<?>) data);
+			} else if( data instanceof Set ) {
+				object = new SetWrapper<>((Set<?>)data);
+			} else {
+				throw new IllegalArgumentException("Unsupported collection type"); //$NON-NLS-1$
+			}
+			try (StringWriter w = new StringWriter()) {
+				JAXBContext jaxbContext = JAXBContext.newInstance( object.getClass(), contentType );
+				Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
+	
+				// output pretty printed
+				jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+	
+				jaxbMarshaller.marshal(object, w);
+				return w.toString();
+			} catch (Throwable e) {
+				throw new RuntimeException(e);
+			}
+		});
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public <O> O deserialize(Class<O> clazz, String value) {
-		if (clazz == List.class) {
-			clazz = (Class<O>) ListWrapper.class;
-		} else if (clazz == Set.class) {
-			clazz = (Class<O>) SetWrapper.class;
-		}
-
-		try (StringReader r = new StringReader(value)) {
-			JAXBContext jaxbContext = JAXBContext.newInstance(clazz );
-
-			Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
-
-			Object unmarshal = jaxbUnmarshaller.unmarshal(r);
-			if (unmarshal instanceof ListWrapper<?>) {
-				return (O) ((ListWrapper<?>) unmarshal).list;
-			} else if (unmarshal instanceof SetWrapper<?>) {
-				return (O) ((SetWrapper<?>) unmarshal).list;
+		return runWithThreadContextCL(() -> {
+			Class<O> cl = clazz;
+			if (cl == List.class) {
+				cl = (Class<O>) ListWrapper.class;
+			} else if (cl == Set.class) {
+				cl = (Class<O>) SetWrapper.class;
 			}
-			return (O) unmarshal;
-		} catch (Throwable e) {
-			throw new RuntimeException(e);
-		}
+	
+			try (StringReader r = new StringReader(value)) {
+				JAXBContext jaxbContext = JAXBContext.newInstance(cl);
+	
+				Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+	
+				Object unmarshal = jaxbUnmarshaller.unmarshal(r);
+				if (unmarshal instanceof ListWrapper<?>) {
+					return (O) ((ListWrapper<?>) unmarshal).list;
+				} else if (unmarshal instanceof SetWrapper<?>) {
+					return (O) ((SetWrapper<?>) unmarshal).list;
+				}
+				return (O) unmarshal;
+			} catch (Throwable e) {
+				throw new RuntimeException(e);
+			}
+		});
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public <O, T extends Collection<O>> T deserializeCollection(Class<T> type, Class<O> contentType, String value) {
-		Class<O> clazz;
-		if ( ((Class<?>)type) == List.class ) {
-			clazz = (Class<O>) ListWrapper.class;
-		} else if (  (Class<?>)type == Set.class) {
-			clazz = (Class<O>) SetWrapper.class;
-		} else {
-			throw new IllegalArgumentException("Unsupported collection type"); //$NON-NLS-1$
-		}
-
-		try (StringReader r = new StringReader(value)) {
-			JAXBContext jaxbContext = JAXBContext.newInstance(clazz, contentType );
-
-			Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
-
-			Object unmarshal = jaxbUnmarshaller.unmarshal(r);
-			if (unmarshal instanceof ListWrapper<?>) {
-				return (T) ((ListWrapper<?>) unmarshal).list;
-			} else if (unmarshal instanceof SetWrapper<?>) {
-				return (T) ((SetWrapper<?>) unmarshal).list;
+		return runWithThreadContextCL(() -> {
+			Class<O> clazz;
+			if ( ((Class<?>)type) == List.class ) {
+				clazz = (Class<O>) ListWrapper.class;
+			} else if (  (Class<?>)type == Set.class) {
+				clazz = (Class<O>) SetWrapper.class;
+			} else {
+				throw new IllegalArgumentException("Unsupported collection type"); //$NON-NLS-1$
 			}
-			throw new IllegalStateException("Unsupported type");
-		} catch (Throwable e) {
-			throw new RuntimeException(e);
+
+			try (StringReader r = new StringReader(value)) {
+				JAXBContext jaxbContext = JAXBContext.newInstance(clazz, contentType );
+	
+				Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+	
+				Object unmarshal = jaxbUnmarshaller.unmarshal(r);
+				if (unmarshal instanceof ListWrapper<?>) {
+					return (T) ((ListWrapper<?>) unmarshal).list;
+				} else if (unmarshal instanceof SetWrapper<?>) {
+					return (T) ((SetWrapper<?>) unmarshal).list;
+				}
+				throw new IllegalStateException("Unsupported type"); //$NON-NLS-1$
+			} catch (Throwable e) {
+				e.printStackTrace();
+				throw new RuntimeException(e);
+			}
+		});
+	}
+	
+	private static <T> T runWithThreadContextCL(Supplier<T> code) {
+		ClassLoader ccl = Thread.currentThread().getContextClassLoader();
+		try {
+			Thread.currentThread().setContextClassLoader(JAXBObjectSerializer.class.getClassLoader());
+			return code.get();
+		} finally {
+			Thread.currentThread().setContextClassLoader(ccl);
 		}
 	}
-
+	
 	/**
 	 * Wraps simple set
 	 *

--- a/releng/org.eclipse.fx.releng/pom.xml
+++ b/releng/org.eclipse.fx.releng/pom.xml
@@ -133,6 +133,11 @@
 			<layout>p2</layout>
 			<url>${efx_shared_runtime}</url>
 		</repository>
+		<repository>
+			<id>orbit </id>
+			<layout>p2</layout>
+			<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20200831200620/repository</url>
+		</repository>
 	</repositories>
 
 	<pluginRepositories>


### PR DESCRIPTION
refs #419 

* Running JAXB with the context class loader set to the callers class loader
* Add optional JAXB dependencies