### PR TITLE
refs #423 - Orbit R20201130205003 does not work with Eclipse 2019-12

### DIFF
--- a/releng/org.eclipse.fx.releng/pom.xml
+++ b/releng/org.eclipse.fx.releng/pom.xml
@@ -134,9 +134,9 @@
 			<url>${efx_shared_runtime}</url>
 		</repository>
 		<repository>
-			<id>orbit </id>
+			<id>orbit</id>
 			<layout>p2</layout>
-			<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20200831200620/repository</url>
+			<url>https://download.eclipse.org/tools/orbit/downloads/drops/R20191126223242/repository</url>
 		</repository>
 	</repositories>
 

--- a/releng/runtime/org.eclipse.fx.target.ext.feature/feature.xml
+++ b/releng/runtime/org.eclipse.fx.target.ext.feature/feature.xml
@@ -2047,5 +2047,12 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+         
+   <plugin
+         id="com.sun.xml.bind"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
 </feature>


### PR DESCRIPTION
Signed-off-by: Christian Baumann <christianbaumann@gmx.at>

refs #423 

Updated to Orbit R20191126223242 and added com.sun.xml.bind to org.eclipse.fx.target.ext.feature.