### PR TITLE
Unsaved-changes dialog wrong behavior when closed by title bar close button

### DIFF
--- a/modules/ui/org.eclipse.fx.ui.dialogs/src/main/java/org/eclipse/fx/ui/dialogs/Dialog.java
+++ b/modules/ui/org.eclipse.fx.ui.dialogs/src/main/java/org/eclipse/fx/ui/dialogs/Dialog.java
@@ -260,6 +260,7 @@ public abstract class Dialog {
 		stage.setTitle(this.title);
 		stage.initOwner(this.parent);
 		stage.initModality(getModality());
+		stage.setOnCloseRequest( evt -> this.setReturnCode( CANCEL_BUTTON ) );
 		Parent content = createContents();
 
 		Pane rootContainer = getCustomWindowPane();


### PR DESCRIPTION
<img width="389" height="164" alt="Image" src="https://github.com/user-attachments/assets/ea956c8c-c497-47f1-a663-1918a623491d" />

When the unsaved-changes dialog `org.eclipse.fx.ui.dialogs.MessageDialog` is closed by clicking on the [x] button all open changes will be saved and the window gets closed. I would expect that the [x] button behaves like the "Cancel" Button (don't save open changes and keep window open)

Reproduce 

- Call  `EPartService.saveAll` on close window to make sure `MessageDialog` is shown to ask for save changes (see code below)
- Click on the [x] button
- Application closes and changes are saved

```
public class CloseHandler implements IWindowCloseHandler {
    @Override
    public boolean close(MWindow window) {
        EPartService service = window.getContext().get(EPartService.class);
        return service.saveAll(true); //Triggers showing of MessageDialog
    }
}
```