### PR TITLE
log widget null error only when widget is supposed to be rendered

### DIFF
--- a/modules/ui/org.eclipse.fx.ui.workbench.renderers.base/src/main/java/org/eclipse/fx/ui/workbench/renderers/base/BaseToolBarRenderer.java
+++ b/modules/ui/org.eclipse.fx.ui.workbench.renderers.base/src/main/java/org/eclipse/fx/ui/workbench/renderers/base/BaseToolBarRenderer.java
@@ -58,7 +58,9 @@ public abstract class BaseToolBarRenderer<N> extends BaseItemContainerRenderer<M
 	public void doProcessContent(MToolBar element) {
 		WToolBar<N> toolbar = getWidget(element);
 		if( toolbar == null ) {
-			getLogger().error("Could not find widget for '"+element+"'");  //$NON-NLS-1$//$NON-NLS-2$
+			if (element.isToBeRendered()) {
+				getLogger().error("Could not find widget for '" + element + "'"); //$NON-NLS-1$//$NON-NLS-2$
+			}
 			return;
 		}
 		for (MToolBarElement item : element.getChildren()) {
@@ -79,7 +81,9 @@ public abstract class BaseToolBarRenderer<N> extends BaseItemContainerRenderer<M
 
 		WToolBar<N> toolbar = getWidget(parentElement);
 		if( toolbar == null ) {
-			getLogger().error("Could not find widget for '"+parentElement+"'"); //$NON-NLS-1$ //$NON-NLS-2$
+			if (parentElement.isToBeRendered()) {
+				getLogger().error("Could not find widget for '" + parentElement + "'"); //$NON-NLS-1$ //$NON-NLS-2$
+			}
 			return;
 		}
 		int idx = getRenderedIndex(parentElement, element);
@@ -87,7 +91,7 @@ public abstract class BaseToolBarRenderer<N> extends BaseItemContainerRenderer<M
 		WWidget<MToolBarElement> widget = (WWidget<MToolBarElement>) element.getWidget();
 		if( widget != null ) {
 			toolbar.addChild(idx, widget);	
-		} else {
+		} else if (element.isToBeRendered()) {
 			this.logger.error("The widget for element '"+element+"' should not be null.");  //$NON-NLS-1$//$NON-NLS-2$
 		}
 		


### PR DESCRIPTION
Fix for: https://github.com/eclipse-efx/efxclipse-rt/issues/456

Log widget null error only when widget is supposed to be rendered. Otherwise widget is allowed to be null
