### PR TITLE
Resolve generics inheritance conflicts and avoid reflection for JavaFX21+

### DIFF
--- a/modules/core/org.eclipse.fx.core/src/main/java/org/eclipse/fx/core/collection/internal/VirtualObservableList.java
+++ b/modules/core/org.eclipse.fx.core/src/main/java/org/eclipse/fx/core/collection/internal/VirtualObservableList.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.fx.core.collection.internal;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalLong;
@@ -104,6 +102,37 @@ public class VirtualObservableList<@Nullable T> implements VirtualList<T> {
 			// TODO need to handle long overflow
 			this.index.set(Math.max(0, this.index.get() + delta));
 		}
+
+		// Overrides to resolve diamond inheritance conflicts with JavaFX 21+ default methods
+		@Override
+		public javafx.beans.value.ObservableValue<T> when(javafx.beans.value.ObservableValue<Boolean> condition) {
+			return super.when(condition);
+		}
+
+		@Override
+		public javafx.util.Subscription subscribe(java.util.function.Consumer<? super T> subscriber) {
+			return super.subscribe(subscriber);
+		}
+
+		@Override
+		public javafx.util.Subscription subscribe(java.util.function.BiConsumer<? super T, ? super T> subscriber) {
+			return super.subscribe(subscriber);
+		}
+
+		@Override
+		public <U> javafx.beans.value.ObservableValue<U> map(java.util.function.Function<? super T, ? extends U> mapper) {
+			return super.map(mapper);
+		}
+
+		@Override
+		public javafx.beans.value.ObservableValue<T> orElse(T value) {
+			return super.orElse(value);
+		}
+
+		@Override
+		public <U> javafx.beans.value.ObservableValue<U> flatMap(java.util.function.Function<? super T, ? extends javafx.beans.value.ObservableValue<? extends U>> mapper) {
+			return super.flatMap(mapper);
+		}
 	}
 
 	class ListViewImpl extends ObservableListBase<T> implements IndexRangeView<T> {
@@ -119,9 +148,7 @@ public class VirtualObservableList<@Nullable T> implements VirtualList<T> {
 			FXObservableUtil.onInvalidate(this.length, v -> updateList());
 			FXObservableUtil.onInvalidate(VirtualObservableList.this.list, o -> updateList());
 
-			this.listener = (c) -> {
-				fireChange(new SourceChangeEvent<T>(this, c));
-			};
+			this.listener = (c) -> fireChange(new SourceChangeEvent<T>(this, c));
 			this.data.addListener(this.listener);
 			updateList();
 		}
@@ -134,7 +161,7 @@ public class VirtualObservableList<@Nullable T> implements VirtualList<T> {
 						(int) Math.min(_endIndex() + 1, VirtualObservableList.this.list.size())));
 			}
 
-			// Fill up the reset of the list
+			// Fill up the rest of the list
 			if (list.size() < size()) {
 				for (int i = list.size(); i < size(); i++) {
 					list.add(null);
@@ -209,22 +236,30 @@ public class VirtualObservableList<@Nullable T> implements VirtualList<T> {
 		public int size() {
 			return this.length.get();
 		}
+
+		// Overrides to resolve diamond inheritance conflicts with JavaFX 21+ default methods
+		@Override
+		public javafx.collections.transformation.FilteredList<T> filtered(java.util.function.Predicate<T> predicate) {
+			return super.filtered(predicate);
+		}
+
+		@Override
+		public javafx.collections.transformation.SortedList<T> sorted(java.util.Comparator<T> comparator) {
+			return super.sorted(comparator);
+		}
+
+		@Override
+		public javafx.collections.transformation.SortedList<T> sorted() {
+			return super.sorted();
+		}
 	}
 
 	static class SourceChangeEvent<T> extends ListChangeListener.Change<T> {
 		private final Change<? extends T> change;
-		private final Method getPermutation;
 
 		public SourceChangeEvent(ObservableList<T> list, Change<? extends T> change) {
 			super(list);
 			this.change = change;
-			try {
-				// TODO We should use MethodHandles
-				this.getPermutation = ListChangeListener.Change.class.getDeclaredMethod("getPermutation"); //$NON-NLS-1$
-				this.getPermutation.setAccessible(true);
-			} catch (NoSuchMethodException | SecurityException e) {
-				throw new IllegalStateException(e);
-			}
 		}
 
 		@Override
@@ -255,11 +290,18 @@ public class VirtualObservableList<@Nullable T> implements VirtualList<T> {
 
 		@Override
 		protected int[] getPermutation() {
-			try {
-				return (int[]) this.getPermutation.invoke(this.change);
-			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-				throw new IllegalStateException(e);
+			// Use the public getPermutation(int) method instead of reflection
+			// to access the protected getPermutation() method
+			if (!this.change.wasPermutated()) {
+				return new int[0];
 			}
+			int from = this.change.getFrom();
+			int to = this.change.getTo();
+			int[] perm = new int[to - from];
+			for (int i = from; i < to; i++) {
+				perm[i - from] = this.change.getPermutation(i);
+			}
+			return perm;
 		}
 
 		@Override


### PR DESCRIPTION
The error reported in #469 appears to be from a stricter requirement for resolving multiple inheritance paths for the same default method. This seems to appears when using Java 22 or higher. However, the changes proposed here should be compatible with Java 21 as well. 

Tested with Maven 3.9.11 using Java 21 and Java 25.

@tomsontom @martinbluehweis 
If this is acceptable, could the Maven repositories be updated with the latest artifacts along with the BOM-style POM file? 